### PR TITLE
flush cron before doing backup

### DIFF
--- a/config/app.conf
+++ b/config/app.conf
@@ -39,6 +39,7 @@ server {
     try_files /assets/compiled/$1 /assets/$1 /assets/stylesheets/compiled/$1 /assets/stylesheets/$1 $uri =404;
   }
 
+  # curl -vv http://localhost:7071/api/jor/dump/export
   set_by_lua $slug_redis_dump_folder_path 'return os.getenv("SLUG_REDIS_DUMP_FOLDER_PATH")';
   location /redis/dump {
     internal;
@@ -52,7 +53,7 @@ server {
     client_body_in_file_only   on;
     client_body_temp_path      /tmp/;
     client_body_buffer_size    200k;
-    client_max_body_size       200M;
+    client_max_body_size       500M;
 
     proxy_pass_request_headers on;
     proxy_set_header           X-FILE $request_body_file;

--- a/lua/controllers/backups_controller.lua
+++ b/lua/controllers/backups_controller.lua
@@ -5,7 +5,10 @@ local redis = require 'resty.redis'
 local backups = {}
 
 function backups.export()
+  crontab.shutdown()
   concurredis.save()
+
+  crontab.initialize()
 
   local folder_path = os.getenv('SLUG_REDIS_DUMP_FOLDER_PATH')
   local file_path   = folder_path .. 'dump.rdb'

--- a/lua/crontab.lua
+++ b/lua/crontab.lua
@@ -333,6 +333,11 @@ crontab.run = function(timer, job_id)
   dict:delete(job_id)
 end
 
+crontab.shutdown = function()
+  crontab.halt()
+  crontab.flush()
+end
+
 crontab.halt = function()
   dict:flush_all()
   dict:flush_expired()


### PR DESCRIPTION
try to execute all cronjobs before the backup is persisted,
that should flush all metrics from collector, traces, etc.
