### PR TITLE
allow chaning service endpoint inside the middleware

### DIFF
--- a/lua/concurredis.lua
+++ b/lua/concurredis.lua
@@ -74,8 +74,9 @@ concurredis.disable_bgsave = function(fun)
     local save = red:config('get', 'save')
 
     local res, err = pcall(fun, red)
-
-    assert(red:config('set', unpack(save)))
+    if save then
+      assert(red:config('set', unpack(save)))
+    end
     assert(res, err)
   end)
 

--- a/lua/middlewares/sanitizer.lua
+++ b/lua/middlewares/sanitizer.lua
@@ -1,6 +1,6 @@
 return function(req, next_middleware, config)
   if req.headers then
-    req.headers.Host = config.endpoint
+    req.headers.Host = string.match(req.endpoint,  "://([^/]+)")
   end
   local res = next_middleware()
   if res.headers then

--- a/lua/models/pipeline.lua
+++ b/lua/models/pipeline.lua
@@ -285,11 +285,11 @@ Pipeline.execute = function(pipeline, endpoint_url)
 
   local trace      = Trace:new(req)
 
+  req.endpoint = endpoint_url
+
   trace.service_id = pipeline.service_id
 
-  rack:use(sanitizer, {
-    endpoint = string.match(endpoint_url, "://([^/]+)")
-  })
+  rack:use(sanitizer)
 
   local ok, res = pcall(function()
     for _,middleware in ipairs(get_active_sorted_middlewares(pipeline)) do
@@ -298,8 +298,7 @@ Pipeline.execute = function(pipeline, endpoint_url)
 
     rack:use(brainslug, {
       trace         = trace,
-      service_id    = pipeline.service_id,
-      endpoint_url  = endpoint_url
+      service_id    = pipeline.service_id
     })
 
     return rack:run(req)

--- a/lua/rack.lua
+++ b/lua/rack.lua
@@ -157,7 +157,8 @@ function Rack:create_initial_request()
     args          = ngx.req.get_uri_args(),
     method        = ngx.var.request_method,
     scheme        = scheme,
-    uri           = uri,
+    uri           = uri, -- # TODO: deprecate this
+    path          = uri,
     host          = host
   }, bodybuilder_mt)
 end

--- a/spec/fixtures/pipelines/change_endpoint_pipeline.json
+++ b/spec/fixtures/pipelines/change_endpoint_pipeline.json
@@ -1,0 +1,14 @@
+{ "_id": 1,
+  "service_id": 1,
+  "middlewares": {
+    "do-nothing":{ "name": "do-nothing",
+      "uuid": "do-nothing",
+      "position": 0,
+      "code": "return function(req, next_middleware) req.endpoint = 'http://lvh-me.lvh.me:10002'; return next_middleware() end",
+      "config": {},
+      "active": true,
+      "spec_id": 0,
+      "description": "pass through of the request and returns response"
+    }
+  }
+}

--- a/spec/fixtures/pipelines/service_two_pipeline.json
+++ b/spec/fixtures/pipelines/service_two_pipeline.json
@@ -1,0 +1,4 @@
+{ "_id": 2,
+  "service_id": 2,
+  "middlewares": {}
+}

--- a/spec/fixtures/services/lvh_service.json
+++ b/spec/fixtures/services/lvh_service.json
@@ -1,0 +1,9 @@
+{ "_id": 2,
+  "name": "lvh",
+  "description": "the echo api",
+  "endpoints": [
+    { "url": "http://lvh.me:8081",
+      "code": "lvh"
+    }
+  ]
+}

--- a/spec/proxy/echo_spec.rb
+++ b/spec/proxy/echo_spec.rb
@@ -13,6 +13,8 @@ describe "echo" do
   let(:service) { load_fixture('services',  'echo_service') }
   before(:each) { service }
 
+  let(:headers) { get_response_key('headers') }
+
   it 'returns the request as a query string when using the echo pipeline' do
     load_fixture('pipelines', 'empty_pipeline')
 
@@ -23,6 +25,13 @@ describe "echo" do
     load_fixture('pipelines', 'echo_pipeline')
 
     get_response_key('path').should eq("/echo")
+  end
+
+  it 'can change endpoint' do
+    load_fixture('services',  'lvh_service')
+    load_fixture('pipelines', 'service_two_pipeline')
+    load_fixture('pipelines', 'change_endpoint_pipeline')
+    expect(headers).to include('host' => 'lvh.me:8081')
   end
 
   it 'uses a minimal middleware that does nothing. different url' do
@@ -109,7 +118,7 @@ describe "echo" do
     jor.wait_for_async_locks
     last_trace_id = get_json('http://localhost:7071/api/traces/last_id')['last_id']
     last_trace = get_json("http://localhost:7071/api/traces/#{last_trace_id}")
-    expect(last_trace).to include('endpoint' => '127.0.0.1:8081')
+    expect(last_trace).to include('endpoint' => 'localhost:8081')
     expect(last_trace).to include('service_id' => service['_id'])
     expect(last_trace).to include('starred' => false)
   end


### PR DESCRIPTION
- added `request.endpoint` which carries the service endpoint
- brainslug middleware uses `request.endpoint` to make the final request

I'm not very happy with the `request.endpoint`. I would prefer some
global object, a service for example. So it would be `service.endpoint`.

But it is much harder to implement. Will give it some time to rest and
see.

allows to change endpoint on the fly in the middleware like:

``` lua
return function(request, next_middleware)
  if request.path == '/some/path' then
    request.endpoint = 'https://example.com'
  end
  return next_middleware()
end
```

fixes #18
